### PR TITLE
+ distinct with query support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 .*.swp
 .settings
 .project
-
+.svn


### PR DESCRIPTION
If we found the options.distinct then we can call collection.distinct("key", spec, function(err, docs) {});
